### PR TITLE
Define a certificate-based API gateway

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "apiManagementServiceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the API Management service to which the API should be added"
+      }
+    },
+    "apiName": {
+      "type": "string"
+    },
+    "productName": {
+      "type": "string"
+    },
+    "swaggerJsonUrl": {
+      "type": "string",
+      "metadata": {
+        "description": "URL to the API's Swagger definition"
+      }
+    },
+    "apiBasePath": {
+      "type": "string",
+      "metadata": {
+        "description": "Base (URL) path to the API operations"
+      }
+    },
+    "apiPolicy": {
+      "type": "string",
+      "metadata": {
+        "description": "API policy (XML)"
+      }
+    }
+  },
+  "variables": {
+    "fullApiName": "[concat('Microsoft.ApiManagement/service/', parameters('apiManagementServiceName'), '/apis/', parameters('apiName'))]",
+    "fullProductName": "[concat('Microsoft.ApiManagement/service/', parameters('apiManagementServiceName'), '/products/', parameters('productName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2017-03-01",
+      "type": "Microsoft.ApiManagement/service/products",
+      "name": "[concat(parameters('apiManagementServiceName') ,'/', parameters('productName'))]",
+      "dependsOn": [
+      ],
+      "properties": {
+        "displayName": "[parameters('productName')]",
+        "subscriptionRequired": false,
+        "state": "published"
+      }
+    },
+    {
+      "apiVersion": "2017-03-01",
+      "type": "Microsoft.ApiManagement/service/apis",
+      "name": "[concat(parameters('apiManagementServiceName'), '/', parameters('apiName'))]",
+      "dependsOn": [
+        "[variables('fullProductName')]"
+      ],
+      "properties": {
+        "contentFormat": "SwaggerLinkJson",
+        "contentValue": "[parameters('swaggerJsonUrl')]",
+        "path": "[parameters('apiBasePath')]"
+      }
+    },
+    {
+      "apiVersion": "2017-03-01",
+      "type": "Microsoft.ApiManagement/service/products/apis",
+      "name": "[concat(parameters('apiManagementServiceName'), '/', parameters('productName'), '/', parameters('apiName'))]",
+      "dependsOn": [
+        "[variables('fullProductName')]",
+        "[variables('fullApiName')]"
+      ]
+    },
+    {
+      "apiVersion": "2017-03-01",
+      "type": "Microsoft.ApiManagement/service/apis/policies",
+      "name": "[concat(parameters('apiManagementServiceName'), '/', parameters('apiName'), '/policy')]",
+      "dependsOn": [
+        "[variables('fullProductName')]",
+        "[variables('fullApiName')]"
+      ],
+      "properties": {
+        "policyContent": "[parameters('apiPolicy')]"
+      }
+    }
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,48 @@
+data "template_file" "namespace_template" {
+  template = "${file("${path.module}/azuredeploy.json")}"
+}
+
+locals {
+  default_resource_group_name         = "core-infra-${var.env}"
+  resource_group_name                 = "${var.resource_group_name == ""
+                                             ? local.default_resource_group_name
+                                             : var.resource_group_name
+                                          }"
+
+  default_api_name                    = "${var.product}-api-gateway-${var.env}"
+  api_name                            = "${var.api_name == "" ? local.default_api_name : var.api_name}"
+
+  default_api_product_name            = "${var.product}-api-product-${var.env}"
+  api_product_name                    = "${var.api_product_name == ""
+                                             ? local.default_api_product_name
+                                             : var.api_product_name
+                                          }"
+
+  default_api_management_service_name = "core-api-mgmt-${var.env}"
+  api_management_service_name         = "${var.api_management_service_name == ""
+                                             ? local.default_api_management_service_name
+                                             : var.api_management_service_name
+                                          }"
+
+  default_api_base_path               = "${var.product}"
+  api_base_path                       = "${var.api_base_path == ""
+                                             ? local.default_api_base_path
+                                             : var.api_base_path
+                                          }"
+}
+
+resource "azurerm_template_deployment" "api" {
+  template_body       = "${data.template_file.namespace_template.rendered}"
+  name                = "${var.product}-api-gateway-${var.env}"
+  deployment_mode     = "Incremental"
+  resource_group_name = "${local.resource_group_name}"
+
+  parameters          = {
+    apiManagementServiceName = "${local.api_management_service_name}"
+    apiName                  = "${local.api_name}"
+    productName              = "${local.api_product_name}"
+    swaggerJsonUrl           = "${var.swagger_json_url}"
+    apiBasePath              = "${local.api_base_path}"
+    apiPolicy                = "${local.api_policy}"
+  }
+}

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,15 @@
+output "base_url" {
+  value = "https://core-api-mgmt-${var.env}.azure-api.net/${local.api_base_path}"
+}
+
+output "api_name" {
+  value = "${local.api_name}"
+}
+
+output "api_product_name" {
+  value = "${local.api_product_name}"
+}
+
+output "resource_group_name" {
+  value = "${local.resource_group_name}"
+}

--- a/policy.tf
+++ b/policy.tf
@@ -1,0 +1,38 @@
+# local variables related with the API's policy
+locals {
+  # certificate thumbprints wrapped in XML-escaped double quotes and comma-separated
+  allowed_cert_thumbprints_string = "${length(var.allowed_certificate_thumbprints) > 0
+                                         ? format("&quot;%s&quot;", join("&quot;,&quot;", var.allowed_certificate_thumbprints))
+                                         : ""
+                                      }"
+
+  backend_service_policy = "${var.backend_app_url == ""
+                                ? ""
+                                : "<set-backend-service base-url=\"${var.backend_app_url}\"/>"
+                             }"
+
+  api_policy = <<EOF
+    <policies>
+        <backend>
+            <base/>
+        </backend>
+        <inbound>
+            <base/>
+            ${local.backend_service_policy}
+            <choose>
+                <when condition="@(context.Request.Certificate == null || !(new string[]{${local.allowed_cert_thumbprints_string}}.Any(t => t.ToUpper() == context.Request.Certificate.Thumbprint.ToUpper())))">
+                    <return-response>
+                        <set-status code="403" reason="Invalid client certificate"/>
+                    </return-response>
+                </when>
+            </choose>
+        </inbound>
+        <outbound>
+            <base/>
+        </outbound>
+        <on-error>
+            <base/>
+        </on-error>
+    </policies>
+  EOF
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,57 @@
+variable "env" {
+  type = "string"
+}
+
+# Name of the product protected by this API. Doesn't need to match any existing name,
+# but should be unique within its environment and obvious enough to tell what that service is.
+variable "product" {
+  type = "string"
+}
+
+# (Optional) Name of the resource group for the API.
+variable "resource_group_name" {
+  type = "string"
+  default = ""
+}
+
+# (Optional) Name of the API to be created
+variable "api_name" {
+  type = "string"
+  default = ""
+}
+
+# (Optional) Name of the API Management service in which the API should be created
+variable "api_management_service_name" {
+  type = "string"
+  default = ""
+}
+
+variable "api_product_name" {
+  type = "string"
+}
+
+# (Optional) The URL that should be used by the API to talk to the backend application.
+# When not provided, the host and protocol defined in Swagger definition is used.
+variable "backend_app_url" {
+  type = "string"
+  default = ""
+}
+
+# URL to the protected API's Swagger JSON definition
+# This JSON has to specify HTTPS as the protocol
+variable "swagger_json_url" {
+  type = "string"
+}
+
+# Thumbprints of accepted client certificates (SSL) - only requests from those clients will be let through
+variable "allowed_certificate_thumbprints" {
+  type = "list"
+  default = []
+}
+
+# (Optional) Base URL path of the API, which will result with the full URL being
+# something like https://core-api-mgmt-....azure-api.net/{base path}
+variable "api_base_path" {
+  type = "string"
+  default = ""
+}


### PR DESCRIPTION
Define a certificate-based API gateway. The list of allowed certificate thumbprints is passed in one of input parameters and only those HTTPS requests where those certificates were used are let through.  All other requests get a 403 response.

Jira story: https://tools.hmcts.net/jira/browse/RPE-503
